### PR TITLE
Fix Firestore query bugs

### DIFF
--- a/lib/service/firestore.dart
+++ b/lib/service/firestore.dart
@@ -146,7 +146,7 @@ class _Firestore {
         .doc(id.toString())
         .get();
 
-    if (snapshot.exists) {
+    if (!snapshot.exists) {
       return null;
     }
 
@@ -243,7 +243,7 @@ class _Firestore {
 
   Future<Medicine> findMedicine(int id) async {
     final doc = await FirebaseFirestore.instance //
-        .collection(_conditionRootName)
+        .collection(_medicineRootName)
         .doc(id.toString())
         .get();
 


### PR DESCRIPTION
## Summary
- correct `findDetailRecord` null check
- use the right collection in `findMedicine`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846dfdbda348332b0398c5903b429a6