### PR TITLE
Fix keyboard not hiding after record saves

### DIFF
--- a/lib/ui/record/record_page.dart
+++ b/lib/ui/record/record_page.dart
@@ -323,6 +323,8 @@ class _ViewBodyState extends ConsumerState<_ViewBody> {
       onSuccess: (_) {/* 成功時は何もしない */},
       onError: (err) => AppDialog.onlyOk(message: err).show(context),
     );
+    // フォーカスを外す
+    FocusScope.of(context).unfocus();
   }
 
   Future<void> _processSaveMedicine(BuildContext context) async {
@@ -340,6 +342,8 @@ class _ViewBodyState extends ConsumerState<_ViewBody> {
       onSuccess: (_) {/* 成功時は何もしない */},
       onError: (err) => AppDialog.onlyOk(message: err).show(context),
     );
+    // フォーカスを外す
+    FocusScope.of(context).unfocus();
   }
 
   Future<void> _processSaveMemo(BuildContext context) async {
@@ -354,6 +358,8 @@ class _ViewBodyState extends ConsumerState<_ViewBody> {
       onSuccess: (_) {/* 成功時は何もしない */},
       onError: (err) => AppDialog.onlyOk(message: err).show(context),
     );
+    // フォーカスを外す
+    FocusScope.of(context).unfocus();
   }
 
   Future<void> _processSaveEvent(BuildContext context) async {
@@ -368,6 +374,8 @@ class _ViewBodyState extends ConsumerState<_ViewBody> {
       onSuccess: (_) {/* 成功時は何もしない */},
       onError: (err) => AppDialog.onlyOk(message: err).show(context),
     );
+    // フォーカスを外す
+    FocusScope.of(context).unfocus();
   }
 }
 


### PR DESCRIPTION
## Summary
- unfocus text fields again after save dialogs complete so the keyboard hides

## Testing
- `dart analyze` *(fails: `dart` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d35d52b7c8332b1f2424a5f7a5575